### PR TITLE
Fix delete event ID expression

### DIFF
--- a/Flow_atendimento_Ana_Paula_Skin (1).json
+++ b/Flow_atendimento_Ana_Paula_Skin (1).json
@@ -2335,7 +2335,7 @@
           "mode": "list",
           "cachedResultName": "anapaulasouskin@gmail.com"
         },
-        "eventId": "={{ $fromAI(\"deleteEvent\") }} ",
+        "eventId": "={{ $fromAI(\"deleteEvent\") }}",
         "options": {}
       },
       "type": "n8n-nodes-base.googleCalendarTool",


### PR DESCRIPTION
## Summary
- remove trailing whitespace from `deleteEvent` variable in Google Calendar node

## Testing
- `jq empty 'Flow_atendimento_Ana_Paula_Skin (1).json'`

------
https://chatgpt.com/codex/tasks/task_e_6853a34015a08333a1b19ed592f00c80